### PR TITLE
Fix import names for SankeyCore

### DIFF
--- a/Sources/MoneyFlowLens/ViewModels.swift
+++ b/Sources/MoneyFlowLens/ViewModels.swift
@@ -1,6 +1,6 @@
 import Foundation
 import SwiftUI
-import Sankey
+import SankeyCore
 
 final class CashFlowViewModel: ObservableObject {
     @Published var client: Client


### PR DESCRIPTION
## Summary
- target MoneyFlowLens at local module `SankeyCore`

## Testing
- `xcodebuild -scheme MoneyFlowLens build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845046c0e1c8326a24282fa786ad3ab