### PR TITLE
Fix missing SankeyDataSet

### DIFF
--- a/Sources/MoneyFlowLens/SankeyDataSet.swift
+++ b/Sources/MoneyFlowLens/SankeyDataSet.swift
@@ -1,0 +1,7 @@
+import Foundation
+import SankeyCore
+
+struct SankeyDataSet {
+    var nodes: [SankeyNode]
+    var links: [SankeyLink]
+}


### PR DESCRIPTION
## Summary
- define `SankeyDataSet` to represent nodes and links for the diagram

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684511cb543c8326811f9f38c1c557af