### PR TITLE
fix(swiftdata): explicit init + remove stale extensions

### DIFF
--- a/Sources/MoneyFlowLens/ExpenseFormView.swift
+++ b/Sources/MoneyFlowLens/ExpenseFormView.swift
@@ -5,7 +5,7 @@ struct ExpenseFormView: View {
     @Environment(\.modelContext) private var context
     @State private var payee = ""
     @State private var amount = 0.0
-    @State private var frequency: Frequency = .monthly
+    @State private var frequency: Frequency = Frequency.monthly
     @State private var nextDue = Date()
     var onSave: () -> Void
 

--- a/Sources/MoneyFlowLens/IncomeFormView.swift
+++ b/Sources/MoneyFlowLens/IncomeFormView.swift
@@ -5,7 +5,7 @@ struct IncomeFormView: View {
     @Environment(\.modelContext) private var context
     @State private var sourceName = ""
     @State private var amount = 0.0
-    @State private var frequency: Frequency = .monthly
+    @State private var frequency: Frequency = Frequency.monthly
     @State private var nextDue = Date()
     var onSave: () -> Void
 

--- a/Sources/MoneyFlowLens/Models.swift
+++ b/Sources/MoneyFlowLens/Models.swift
@@ -20,24 +20,72 @@ enum ExpenseCategory: String, CaseIterable, Codable {
     var income      : [IncomeItem]  = []
     @Relationship(deleteRule: .cascade)
     var expenses    : [ExpenseItem] = []
+
+    init(
+        id: UUID = .init(),
+        displayName: String = "",
+        createdDate: Date = .now,
+        income: [IncomeItem] = [],
+        expenses: [ExpenseItem] = []
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.createdDate = createdDate
+        self.income = income
+        self.expenses = expenses
+    }
 }
 
 @Model final class IncomeItem {
     var id         : UUID        = .init()
     var sourceName : String      = ""
     var amount     : Decimal     = .zero
-    var frequency  : Frequency   = .monthly
+    var frequency  : Frequency   = Frequency.monthly
     var nextDue    : Date        = .now
     @Relationship(inverse: \ExpenseItem.incomeOwner)
     var owner      : Client?     // optional back-link
+
+    init(
+        id: UUID = .init(),
+        sourceName: String = "",
+        amount: Decimal = .zero,
+        frequency: Frequency = Frequency.monthly,
+        nextDue: Date = .now,
+        owner: Client? = nil
+    ) {
+        self.id = id
+        self.sourceName = sourceName
+        self.amount = amount
+        self.frequency = frequency
+        self.nextDue = nextDue
+        self.owner = owner
+    }
 }
 
 @Model final class ExpenseItem {
     var id         : UUID            = .init()
     var payee      : String          = ""
     var amount     : Decimal         = .zero
-    var frequency  : Frequency       = .monthly
+    var frequency  : Frequency       = Frequency.monthly
     var nextDue    : Date            = .now
-    var category   : ExpenseCategory = .discretionary
+    var category   : ExpenseCategory = ExpenseCategory.discretionary
     @Relationship var incomeOwner    : Client?   // inverse side
+
+    init(
+        id: UUID = .init(),
+        payee: String = "",
+        amount: Decimal = .zero,
+        frequency: Frequency = Frequency.monthly,
+        nextDue: Date = .now,
+        category: ExpenseCategory = ExpenseCategory.discretionary,
+        incomeOwner: Client? = nil
+    ) {
+        self.id = id
+        self.payee = payee
+        self.amount = amount
+        self.frequency = frequency
+        self.nextDue = nextDue
+        self.category = category
+        self.incomeOwner = incomeOwner
+    }
 }


### PR DESCRIPTION
## Summary
- add explicit initialisers to SwiftData models
- use fully qualified enum defaults
- clean up forms to match new enum usage

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684515b416088326a7f67cc8ff3f06e0