### PR TITLE
Fix ForEach enum & initializer defaults

### DIFF
--- a/Sources/MoneyFlowLens/ExpenseFormView.swift
+++ b/Sources/MoneyFlowLens/ExpenseFormView.swift
@@ -15,7 +15,7 @@ struct ExpenseFormView: View {
             TextField("Amount", value: $amount, formatter: NumberFormatter())
             Picker("Frequency", selection: $frequency) {
                 ForEach(Frequency.allCases) { freq in
-                    Text(freq.rawValue).tag(freq)
+                    Text(freq.rawValueLabel).tag(freq)
                 }
             }
             DatePicker("Next Due", selection: $nextDue)

--- a/Sources/MoneyFlowLens/IncomeFormView.swift
+++ b/Sources/MoneyFlowLens/IncomeFormView.swift
@@ -15,7 +15,7 @@ struct IncomeFormView: View {
             TextField("Amount", value: $amount, formatter: NumberFormatter())
             Picker("Frequency", selection: $frequency) {
                 ForEach(Frequency.allCases) { freq in
-                    Text(freq.rawValue).tag(freq)
+                    Text(freq.rawValueLabel).tag(freq)
                 }
             }
             DatePicker("Next Due", selection: $nextDue)

--- a/Sources/MoneyFlowLens/Models.swift
+++ b/Sources/MoneyFlowLens/Models.swift
@@ -2,8 +2,14 @@ import Foundation
 import SwiftData   // still needed
 
 // MARK: - Frequency enum used by both models
-enum Frequency: String, CaseIterable, Codable {
+enum Frequency: String, CaseIterable, Codable, Identifiable {
     case weekly, fortnightly, monthly, yearly
+
+    /// Conformance to ``Identifiable`` allows use in `ForEach` without extra `id:` parameter.
+    var id: Self { self }
+
+    /// User-facing label for picker rows.
+    var rawValueLabel: String { rawValue.capitalized }
 }
 
 // MARK: - ExpenseCategory used by ExpenseItem
@@ -13,18 +19,18 @@ enum ExpenseCategory: String, CaseIterable, Codable {
 
 // MARK: - SwiftData models  (must be classes in Xcode 16+)
 @Model final class Client {
-    var id          : UUID          = .init()
+    var id          : UUID          = UUID()
     var displayName : String        = ""
-    var createdDate : Date          = .now
+    var createdDate : Date          = Date()
     @Relationship(deleteRule: .cascade)
     var income      : [IncomeItem]  = []
     @Relationship(deleteRule: .cascade)
     var expenses    : [ExpenseItem] = []
 
     init(
-        id: UUID = .init(),
+        id: UUID = UUID(),
         displayName: String = "",
-        createdDate: Date = .now,
+        createdDate: Date = Date(),
         income: [IncomeItem] = [],
         expenses: [ExpenseItem] = []
     ) {
@@ -37,20 +43,20 @@ enum ExpenseCategory: String, CaseIterable, Codable {
 }
 
 @Model final class IncomeItem {
-    var id         : UUID        = .init()
+    var id         : UUID        = UUID()
     var sourceName : String      = ""
-    var amount     : Decimal     = .zero
+    var amount     : Decimal     = Decimal.zero
     var frequency  : Frequency   = Frequency.monthly
-    var nextDue    : Date        = .now
+    var nextDue    : Date        = Date()
     @Relationship(inverse: \ExpenseItem.incomeOwner)
     var owner      : Client?     // optional back-link
 
     init(
-        id: UUID = .init(),
+        id: UUID = UUID(),
         sourceName: String = "",
-        amount: Decimal = .zero,
+        amount: Decimal = Decimal.zero,
         frequency: Frequency = Frequency.monthly,
-        nextDue: Date = .now,
+        nextDue: Date = Date(),
         owner: Client? = nil
     ) {
         self.id = id
@@ -63,20 +69,20 @@ enum ExpenseCategory: String, CaseIterable, Codable {
 }
 
 @Model final class ExpenseItem {
-    var id         : UUID            = .init()
+    var id         : UUID            = UUID()
     var payee      : String          = ""
-    var amount     : Decimal         = .zero
+    var amount     : Decimal         = Decimal.zero
     var frequency  : Frequency       = Frequency.monthly
-    var nextDue    : Date            = .now
+    var nextDue    : Date            = Date()
     var category   : ExpenseCategory = ExpenseCategory.discretionary
     @Relationship var incomeOwner    : Client?   // inverse side
 
     init(
-        id: UUID = .init(),
+        id: UUID = UUID(),
         payee: String = "",
-        amount: Decimal = .zero,
+        amount: Decimal = Decimal.zero,
         frequency: Frequency = Frequency.monthly,
-        nextDue: Date = .now,
+        nextDue: Date = Date(),
         category: ExpenseCategory = ExpenseCategory.discretionary,
         incomeOwner: Client? = nil
     ) {


### PR DESCRIPTION
## Summary
- make `Frequency` enum Identifiable to use in `ForEach`
- update pickers to use `rawValueLabel`
- remove shorthand default values in SwiftData models

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68451744a2a883268c85f0026890f5dd