### PR TITLE
Add ExpenseItem auto categorisation helper

### DIFF
--- a/Sources/MoneyFlowLens/ExpenseItem+AutoCategorise.swift
+++ b/Sources/MoneyFlowLens/ExpenseItem+AutoCategorise.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension ExpenseItem {
+    /// Categorise an expense based on simple keyword rules.
+    /// Call this right after creating the object (e.g. in ExpenseFormView).
+    func autoCategorise() {
+        let p = payee.lowercased()
+
+        if p.contains("mortgage")
+            || p.contains("rent")
+            || p.contains("utility")
+            || p.contains("insurance") {
+
+            category = .householdOverhead     // adjust enum cases if yours differ
+        }
+        else if p.contains("401k")
+            || p.contains("ira")
+            || p.contains("brokerage") {
+
+            category = .investing
+        }
+        else if p.contains("saving")
+            || p.contains("emergency") {
+
+            category = .savings
+        }
+        else {
+            category = .discretionary
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing helper extension for `ExpenseItem` so expenses can be auto‑categorised

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68451a3169ac832684335e5c79190195